### PR TITLE
FIX: rclone - directory listing broken by rclone log messages

### DIFF
--- a/sdk/wfxplugin.h
+++ b/sdk/wfxplugin.h
@@ -1,187 +1,132 @@
 #include "common.h"
 
-// contents of fsplugin.h  version 2.0 (30.Jan.2009)
+// contents of fsplugin.h  version 2.1 (27.April.2010)
 
 // ids for FsGetFile
-
 #define FS_FILE_OK 0
-
 #define FS_FILE_EXISTS 1
-
 #define FS_FILE_NOTFOUND 2
-
 #define FS_FILE_READERROR 3
-
 #define FS_FILE_WRITEERROR 4
-
 #define FS_FILE_USERABORT 5
-
 #define FS_FILE_NOTSUPPORTED 6
-
 #define FS_FILE_EXISTSRESUMEALLOWED 7
 
 #define FS_EXEC_OK 0
-
 #define FS_EXEC_ERROR 1
-
 #define FS_EXEC_YOURSELF -1
-
 #define FS_EXEC_SYMLINK -2
 
 #define FS_COPYFLAGS_OVERWRITE 1
-
 #define FS_COPYFLAGS_RESUME 2
-
 #define FS_COPYFLAGS_MOVE 4
-
 #define FS_COPYFLAGS_EXISTS_SAMECASE 8
-
 #define FS_COPYFLAGS_EXISTS_DIFFERENTCASE 16
 
- 
-
 // flags for tRequestProc
-
 #define RT_Other 0
-
 #define RT_UserName 1
-
 #define RT_Password 2
-
 #define RT_Account 3
-
 #define RT_UserNameFirewall 4
-
 #define RT_PasswordFirewall 5
-
 #define RT_TargetDir 6
-
 #define RT_URL 7
-
 #define RT_MsgOK 8
-
 #define RT_MsgYesNo 9
-
 #define RT_MsgOKCancel 10
 
 // flags for tLogProc
-
 #define MSGTYPE_CONNECT 1
-
 #define MSGTYPE_DISCONNECT 2
-
 #define MSGTYPE_DETAILS 3
-
 #define MSGTYPE_TRANSFERCOMPLETE 4
-
 #define MSGTYPE_CONNECTCOMPLETE 5
-
 #define MSGTYPE_IMPORTANTERROR 6
-
 #define MSGTYPE_OPERATIONCOMPLETE 7
 
 // flags for FsStatusInfo
-
 #define FS_STATUS_START 0
-
 #define FS_STATUS_END 1
 
 #define FS_STATUS_OP_LIST 1
-
 #define FS_STATUS_OP_GET_SINGLE 2
-
 #define FS_STATUS_OP_GET_MULTI 3
-
 #define FS_STATUS_OP_PUT_SINGLE 4
-
 #define FS_STATUS_OP_PUT_MULTI 5
-
 #define FS_STATUS_OP_RENMOV_SINGLE 6
-
 #define FS_STATUS_OP_RENMOV_MULTI 7
-
 #define FS_STATUS_OP_DELETE 8
-
 #define FS_STATUS_OP_ATTRIB 9
-
 #define FS_STATUS_OP_MKDIR 10
-
 #define FS_STATUS_OP_EXEC 11
-
 #define FS_STATUS_OP_CALCSIZE 12
-
 #define FS_STATUS_OP_SEARCH 13
-
 #define FS_STATUS_OP_SEARCH_TEXT 14
-
 #define FS_STATUS_OP_SYNC_SEARCH 15
-
 #define FS_STATUS_OP_SYNC_GET 16
-
 #define FS_STATUS_OP_SYNC_PUT 17
-
 #define FS_STATUS_OP_SYNC_DELETE 18
+#define FS_STATUS_OP_GET_MULTI_THREAD 19
+#define FS_STATUS_OP_PUT_MULTI_THREAD 20
 
 #define FS_ICONFLAG_SMALL 1
-
 #define FS_ICONFLAG_BACKGROUND 2
 
 #define FS_ICON_USEDEFAULT 0
-
 #define FS_ICON_EXTRACTED 1
-
 #define FS_ICON_EXTRACTED_DESTROY 2
-
 #define FS_ICON_DELAYED 3
 
 #define FS_BITMAP_NONE 0
-
 #define FS_BITMAP_EXTRACTED 1
-
 #define FS_BITMAP_EXTRACT_YOURSELF 2
-
 #define FS_BITMAP_EXTRACT_YOURSELF_ANDDELETE 3
-
 #define FS_BITMAP_CACHE 256
 
 #define FS_CRYPT_SAVE_PASSWORD 1
-
 #define FS_CRYPT_LOAD_PASSWORD 2
-
 #define FS_CRYPT_LOAD_PASSWORD_NO_UI 3 // Load password only if master password has already been entered!
-
 #define FS_CRYPT_COPY_PASSWORD 4       // Copy encrypted password to new connection name
-
 #define FS_CRYPT_MOVE_PASSWORD 5       // Move password when renaming a connection
-
 #define FS_CRYPT_DELETE_PASSWORD 6     // Delete password
 
 #define FS_CRYPTOPT_MASTERPASS_SET 1   // The user already has a master password defined
 
+#define BG_DOWNLOAD 1                  // Plugin supports downloads in background
+#define BG_UPLOAD 2                    // Plugin supports uploads in background
+#define BG_ASK_USER 4                  // Plugin requires separate connection for background transfers -> ask user first
+
 // flags for FsFindFirst/FsFindNext
-
 #define FILE_ATTRIBUTE_DIRECTORY 16
-
 #define FILE_ATTRIBUTE_REPARSE_POINT 0x00000400
-
 #define FILE_ATTRIBUTE_UNIX_MODE 0x80000000
 
+// custom icons
+#define FS_ICON_FORMAT_HICON  0 // Load icon from HICON (Windows only)
+#define FS_ICON_FORMAT_FILE   1 // Load icon from file name returned by plugin in the RemoteName
+#define FS_ICON_FORMAT_BINARY 2 // Load icon from Data byte array (PNG or ICO), destroy data using Free if FS_ICON_EXTRACTED_DESTROY returned
+
+typedef void (DCPCALL *tFreeProc)(void* Pointer);
+
 typedef struct {
+    void* Pointer;
+    uintptr_t Size;
+    uintptr_t Format;
+    tFreeProc Free;
+} TWfxIcon,*PWfxIcon;
 
+typedef struct {
     DWORD SizeLow,SizeHigh;
-
     FILETIME LastWriteTime;
-
     int Attr;
-
 } RemoteInfoStruct;
 
 typedef struct {
-
-int size;
-	DWORD PluginInterfaceVersionLow;
-	DWORD PluginInterfaceVersionHi;
-	char DefaultIniName[MAX_PATH];
+    int size;
+    DWORD PluginInterfaceVersionLow;
+    DWORD PluginInterfaceVersionHi;
+    char DefaultIniName[MAX_PATH];
 } FsDefaultParamStruct;
 
 // callback functions
@@ -197,9 +142,9 @@ typedef BOOL (DCPCALL *tRequestProc)(int PluginNr,int RequestType,char* CustomTi
 typedef BOOL (DCPCALL *tRequestProcW)(int PluginNr,int RequestType,WCHAR* CustomTitle,
               WCHAR* CustomText,WCHAR* ReturnedText,int maxlen);
 typedef int (DCPCALL *tCryptProc)(int PluginNr,int CryptoNr,int Mode,
-			  char* ConnectionName,char* Password,int maxlen);
+              char* ConnectionName,char* Password,int maxlen);
 typedef int (DCPCALL *tCryptProcW)(int PluginNr,int CryptoNr,int Mode,
-			  WCHAR* ConnectionName,WCHAR* Password,int maxlen);
+              WCHAR* ConnectionName,WCHAR* Password,int maxlen);
 
 // Function prototypes
 int DCPCALL FsInit(int PluginNr,tProgressProc pProgressProc,
@@ -245,8 +190,8 @@ BOOL DCPCALL FsSetTimeW(WCHAR* RemoteName,FILETIME *CreationTime,
 void DCPCALL FsStatusInfo(char* RemoteDir,int InfoStartEnd,int InfoOperation);
 void DCPCALL FsStatusInfoW(WCHAR* RemoteDir,int InfoStartEnd,int InfoOperation);
 void DCPCALL FsGetDefRootName(char* DefRootName,int maxlen);
-int DCPCALL FsExtractCustomIcon(char* RemoteName,int ExtractFlags,HICON* TheIcon);
-int DCPCALL FsExtractCustomIconW(WCHAR* RemoteName,int ExtractFlags,HICON* TheIcon);
+int DCPCALL FsExtractCustomIcon(char* RemoteName,int ExtractFlags,PWfxIcon TheIcon);
+int DCPCALL FsExtractCustomIconW(WCHAR* RemoteName,int ExtractFlags,PWfxIcon TheIcon);
 void DCPCALL FsSetDefaultParams(FsDefaultParamStruct* dps);
 
 int DCPCALL FsGetPreviewBitmap(char* RemoteName,int width,int height,HBITMAP* ReturnedBitmap);
@@ -306,20 +251,19 @@ typedef struct {
     int size;
     DWORD PluginInterfaceVersionLow;
     DWORD PluginInterfaceVersionHi;
-
     char DefaultIniName[MAX_PATH];
 } ContentDefaultParamStruct;
 
 typedef struct {
-	WORD wYear;
-	WORD wMonth;
-	WORD wDay;
+    WORD wYear;
+    WORD wMonth;
+    WORD wDay;
 } tdateformat,*pdateformat;
 
 typedef struct {
-	WORD wHour;
-	WORD wMinute;
-	WORD wSecond;
+    WORD wHour;
+    WORD wMinute;
+    WORD wSecond;
 } ttimeformat,*ptimeformat;
 
 int DCPCALL FsContentGetSupportedField(int FieldIndex,char* FieldName,char* Units,int maxlen);

--- a/sdk/wfxplugin.pas
+++ b/sdk/wfxplugin.pas
@@ -207,6 +207,20 @@ type
   HICON = THandle;
   HWND = THandle;
 
+const
+  FS_ICON_FORMAT_HICON  = 0; // Load icon from HICON (Windows only)
+  FS_ICON_FORMAT_FILE   = 1; // Load icon from file name returned by plugin in the RemoteName
+  FS_ICON_FORMAT_BINARY = 2; // Load icon from Data byte array (PNG or ICO), destroy data using Free if FS_ICON_EXTRACTED_DESTROY returned
+
+type
+  PWfxIcon = ^TWfxIcon;
+  TWfxIcon = packed record
+    Data: Pointer;   // Icon data
+    Size: UIntPtr;   // Input: suggested icon size (width/height), output: size of Data byte array
+    Format: UIntPtr; // See FS_ICON_FORMAT_*
+    Free: procedure(Data: Pointer); {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF}; // Procedure used to destroy Data byte array
+  end;
+
 type
 {$IFDEF MSWINDOWS}
   FILETIME = Windows.FILETIME;
@@ -407,21 +421,21 @@ procedure FsGetDefRootName(DefRootName:pchar;maxlen:integer); {$IFDEF MSWINDOWS}
 
 function FsExtractCustomIcon(RemoteName:pchar;ExtractFlags:integer;
 
-  var TheIcon:hicon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
+  TheIcon: PWfxIcon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 
 function FsExtractCustomIconW(RemoteName:pwidechar;ExtractFlags:integer;
 
-  var TheIcon:hicon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
+  TheIcon: PWfxIcon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 
 procedure FsSetDefaultParams(dps:pFsDefaultParamStruct); {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 
 function FsGetPreviewBitmap(RemoteName:pchar;width,height:integer,
 
-  var ReturnedBitmap:hbitmap):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
+  ReturnedBitmap: PWfxIcon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 
 function FsGetPreviewBitmapW(RemoteName:pwidechar;width,height:integer,
 
-  var ReturnedBitmap:hbitmap):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
+  ReturnedBitmap: PWfxIcon):integer; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 
 function FsLinksToLocalFiles:bool; {$IFDEF MSWINDOWS}stdcall{$ELSE}cdecl{$ENDIF};
 

--- a/wfx/rclone/build/build_linux.sh
+++ b/wfx/rclone/build/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build rclone WFX plugin on Debian 12 (x86_64)
-# Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+# Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 #
 # Usage:
 #   sudo ./build_linux.sh         Build the plugin (installs dependencies)

--- a/wfx/rclone/build/build_macos.sh
+++ b/wfx/rclone/build/build_macos.sh
@@ -11,7 +11,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SRC_DIR="$PLUGIN_DIR/src"
-SDK_DIR="$PLUGIN_DIR/../../../sdk"
+SDK_DIR="$PLUGIN_DIR/../../sdk"
 OUTPUT="$PLUGIN_DIR/rclone.wfx"
 LIB_DIR="$PLUGIN_DIR/lib"
 

--- a/wfx/rclone/build/build_macos.sh
+++ b/wfx/rclone/build/build_macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build rclone WFX plugin on macOS using Free Pascal
-# Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+# Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 #
 # Usage:
 #   ./build_macos.sh         Build the plugin

--- a/wfx/rclone/build/build_windows.bat
+++ b/wfx/rclone/build/build_windows.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 :: Build rclone WFX plugin on Windows
-:: Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+:: Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 :: Requires Lazarus IDE installed
 ::
 :: Usage:

--- a/wfx/rclone/src/rclone.lpi
+++ b/wfx/rclone/src/rclone.lpi
@@ -30,8 +30,8 @@
             <Filename Value="..\rclone.wfx" ApplyConventions="False"/>
           </Target>
           <SearchPaths>
-            <IncludeFiles Value="$(ProjOutDir);..\..\..\..\sdk"/>
-            <OtherUnitFiles Value="..\..\..\..\sdk"/>
+            <IncludeFiles Value="$(ProjOutDir);..\..\..\sdk"/>
+            <OtherUnitFiles Value="..\..\..\sdk"/>
             <UnitOutputDirectory Value="..\lib"/>
           </SearchPaths>
           <Conditionals Value="if (TargetCPU &lt;> &apos;arm&apos;) then
@@ -124,8 +124,8 @@ end;"/>
       <Filename Value="..\rclone.wfx" ApplyConventions="False"/>
     </Target>
     <SearchPaths>
-      <IncludeFiles Value="$(ProjOutDir);..\..\..\..\sdk"/>
-      <OtherUnitFiles Value="..\..\..\..\sdk"/>
+      <IncludeFiles Value="$(ProjOutDir);..\..\..\sdk"/>
+      <OtherUnitFiles Value="..\..\..\sdk"/>
       <UnitOutputDirectory Value="..\lib"/>
     </SearchPaths>
     <Conditionals Value="if (TargetCPU &lt;> &apos;arm&apos;) then

--- a/wfx/rclone/src/rclone.lpr
+++ b/wfx/rclone/src/rclone.lpr
@@ -5,7 +5,7 @@ library rclone;
    -------------------------------------------------------------------------
    WFX plugin for working with rclone remotes
 
-   Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+   Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/wfx/rclone/src/rclone.lpr
+++ b/wfx/rclone/src/rclone.lpr
@@ -55,4 +55,14 @@ exports
 {$R *.res}
 
 begin
+  { A plugin is a shared library with its own RTL instance, so it gets the RTL's
+    default code page (CP_ACP) rather than the host's. Combined with the fallback
+    widestring manager (no cwstring), every UnicodeString -> AnsiString conversion
+    would then replace code points above U+007F with '?' - which is what fpjson does
+    internally while scanning the JSON that rclone prints. Declaring UTF-8 up front
+    keeps non-ASCII file names intact on the way in and out. }
+  DefaultSystemCodePage := CP_UTF8;
+  DefaultUnicodeCodePage := CP_UTF8;
+  DefaultFileSystemCodePage := CP_UTF8;
+  DefaultRTLFileSystemCodePage := CP_UTF8;
 end.

--- a/wfx/rclone/src/urclonecli.pas
+++ b/wfx/rclone/src/urclonecli.pas
@@ -36,12 +36,12 @@ type
   TRcloneCli = class
   private
     FRclonePath: AnsiString;
-    FLastError: AnsiString;
+    FLastError: RawByteString;
     FProgressProc: TProgressCallback;
     FPluginNr: Integer;
-    function RunCommand(const Args: array of AnsiString; out Output: AnsiString;
-      out ErrorOutput: AnsiString; out ExitCode: Integer): Boolean;
-    function RunCommandWithProgress(const Args: array of AnsiString;
+    function RunCommand(const Args: array of RawByteString; out Output: RawByteString;
+      out ErrorOutput: RawByteString; out ExitCode: Integer): Boolean;
+    function RunCommandWithProgress(const Args: array of RawByteString;
       const SourceName, TargetName: UnicodeString;
       out ExitCode: Integer): Boolean;
     function ParseProgressPercentage(const Line: AnsiString): Integer;
@@ -56,22 +56,22 @@ type
     function ListRemotes: TStringList;
 
     { List directory contents }
-    function ListDirectory(const RemotePath: AnsiString): TRcloneFileList;
+    function ListDirectory(const RemotePath: RawByteString): TRcloneFileList;
 
     { File operations }
-    function CopyToLocal(const RemotePath, LocalPath: AnsiString): Integer;
-    function CopyToRemote(const LocalPath, RemotePath: AnsiString): Integer;
-    function DeleteFile(const RemotePath: AnsiString): Boolean;
-    function DeleteDir(const RemotePath: AnsiString): Boolean;
-    function MakeDir(const RemotePath: AnsiString): Boolean;
-    function MoveFile(const OldPath, NewPath: AnsiString): Boolean;
+    function CopyToLocal(const RemotePath, LocalPath: RawByteString): Integer;
+    function CopyToRemote(const LocalPath, RemotePath: RawByteString): Integer;
+    function DeleteFile(const RemotePath: RawByteString): Boolean;
+    function DeleteDir(const RemotePath: RawByteString): Boolean;
+    function MakeDir(const RemotePath: RawByteString): Boolean;
+    function MoveFile(const OldPath, NewPath: RawByteString): Boolean;
 
     property RclonePath: AnsiString read FRclonePath write FRclonePath;
-    property LastError: AnsiString read FLastError;
+    property LastError: RawByteString read FLastError;
   end;
 
 { Map rclone exit codes to WFX results }
-function RcloneExitToWfx(ExitCode: Integer; const ErrorOutput: AnsiString): Integer;
+function RcloneExitToWfx(ExitCode: Integer; const ErrorOutput: RawByteString): Integer;
 
 implementation
 
@@ -161,7 +161,7 @@ end;
 
 { Read everything currently buffered in a pipe without blocking.
   Returns the number of bytes appended to AStream. }
-function DrainPipe(APipe: TInputPipeStream; AStream: TStringStream): Integer;
+function DrainPipe(APipe: TInputPipeStream; AStream: TStream): Integer;
 var
   Buffer: array[0..4095] of Byte;
   Avail, BytesRead: Integer;
@@ -180,12 +180,23 @@ begin
   until False;
 end;
 
-function TRcloneCli.RunCommand(const Args: array of AnsiString;
-  out Output: AnsiString; out ErrorOutput: AnsiString; out ExitCode: Integer): Boolean;
+{ Materialize a stream's bytes verbatim. Deliberately not TStringStream.DataString,
+  which decodes and re-encodes through TEncoding.Default and would corrupt UTF-8 file
+  names whenever the system code page is not UTF-8. }
+function StreamToRawBytes(AStream: TMemoryStream): RawByteString;
+begin
+  if AStream.Size = 0 then
+    Result := ''
+  else
+    SetString(Result, PAnsiChar(AStream.Memory), AStream.Size);
+end;
+
+function TRcloneCli.RunCommand(const Args: array of RawByteString;
+  out Output: RawByteString; out ErrorOutput: RawByteString; out ExitCode: Integer): Boolean;
 var
   AProcess: TProcess;
   I: Integer;
-  OutputStream, ErrorStream: TStringStream;
+  OutputStream, ErrorStream: TMemoryStream;
   ConfigPath: AnsiString;
 begin
   Result := False;
@@ -195,8 +206,8 @@ begin
   FLastError := '';
 
   AProcess := TProcess.Create(nil);
-  OutputStream := TStringStream.Create('');
-  ErrorStream := TStringStream.Create('');
+  OutputStream := TMemoryStream.Create;
+  ErrorStream := TMemoryStream.Create;
   try
     AProcess.Executable := FRclonePath;
 
@@ -234,8 +245,8 @@ begin
       until False;
 
       ExitCode := AProcess.ExitCode;
-      Output := OutputStream.DataString;
-      ErrorOutput := ErrorStream.DataString;
+      Output := StreamToRawBytes(OutputStream);
+      ErrorOutput := StreamToRawBytes(ErrorStream);
       Result := True;
     except
       on E: Exception do
@@ -279,7 +290,7 @@ begin
   end;
 end;
 
-function TRcloneCli.RunCommandWithProgress(const Args: array of AnsiString;
+function TRcloneCli.RunCommandWithProgress(const Args: array of RawByteString;
   const SourceName, TargetName: UnicodeString;
   out ExitCode: Integer): Boolean;
 var
@@ -397,7 +408,7 @@ end;
 
 function TRcloneCli.ListRemotes: TStringList;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := nil;
@@ -410,9 +421,9 @@ begin
   end;
 end;
 
-function TRcloneCli.ListDirectory(const RemotePath: AnsiString): TRcloneFileList;
+function TRcloneCli.ListDirectory(const RemotePath: RawByteString): TRcloneFileList;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := nil;
@@ -425,7 +436,7 @@ begin
   end;
 end;
 
-function TRcloneCli.CopyToLocal(const RemotePath, LocalPath: AnsiString): Integer;
+function TRcloneCli.CopyToLocal(const RemotePath, LocalPath: RawByteString): Integer;
 var
   ExitCode: Integer;
 begin
@@ -443,7 +454,7 @@ begin
     Result := FS_FILE_READERROR;
 end;
 
-function TRcloneCli.CopyToRemote(const LocalPath, RemotePath: AnsiString): Integer;
+function TRcloneCli.CopyToRemote(const LocalPath, RemotePath: RawByteString): Integer;
 var
   ExitCode: Integer;
 begin
@@ -461,9 +472,9 @@ begin
     Result := FS_FILE_WRITEERROR;
 end;
 
-function TRcloneCli.DeleteFile(const RemotePath: AnsiString): Boolean;
+function TRcloneCli.DeleteFile(const RemotePath: RawByteString): Boolean;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := RunCommand(['delete', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
@@ -471,9 +482,9 @@ begin
     FLastError := ErrorOutput;
 end;
 
-function TRcloneCli.DeleteDir(const RemotePath: AnsiString): Boolean;
+function TRcloneCli.DeleteDir(const RemotePath: RawByteString): Boolean;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := RunCommand(['rmdir', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
@@ -481,9 +492,9 @@ begin
     FLastError := ErrorOutput;
 end;
 
-function TRcloneCli.MakeDir(const RemotePath: AnsiString): Boolean;
+function TRcloneCli.MakeDir(const RemotePath: RawByteString): Boolean;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := RunCommand(['mkdir', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
@@ -491,9 +502,9 @@ begin
     FLastError := ErrorOutput;
 end;
 
-function TRcloneCli.MoveFile(const OldPath, NewPath: AnsiString): Boolean;
+function TRcloneCli.MoveFile(const OldPath, NewPath: RawByteString): Boolean;
 var
-  Output, ErrorOutput: AnsiString;
+  Output, ErrorOutput: RawByteString;
   ExitCode: Integer;
 begin
   Result := RunCommand(['moveto', OldPath, NewPath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
@@ -501,9 +512,9 @@ begin
     FLastError := ErrorOutput;
 end;
 
-function RcloneExitToWfx(ExitCode: Integer; const ErrorOutput: AnsiString): Integer;
+function RcloneExitToWfx(ExitCode: Integer; const ErrorOutput: RawByteString): Integer;
 var
-  LowerError: AnsiString;
+  LowerError: RawByteString;
 begin
   case ExitCode of
     0: Result := FS_FILE_OK;

--- a/wfx/rclone/src/urclonecli.pas
+++ b/wfx/rclone/src/urclonecli.pas
@@ -52,10 +52,12 @@ type
     { Initialize with callback functions }
     procedure Initialize(PluginNr: Integer; ProgressProc: TProgressCallback);
 
-    { List all configured remotes }
+    { List all configured remotes. Returns nil if rclone failed; an empty list
+      means rclone succeeded and there are no remotes. LastError has the details. }
     function ListRemotes: TStringList;
 
-    { List directory contents }
+    { List directory contents. Returns nil if rclone failed; an empty list means
+      rclone succeeded and the directory is empty. LastError has the details. }
     function ListDirectory(const RemotePath: RawByteString): TRcloneFileList;
 
     { File operations }
@@ -415,10 +417,7 @@ begin
   if RunCommand(['listremotes'], Output, ErrorOutput, ExitCode) and (ExitCode = 0) then
     Result := ParseListRemotes(Output)
   else
-  begin
     FLastError := ErrorOutput;
-    Result := TStringList.Create;
-  end;
 end;
 
 function TRcloneCli.ListDirectory(const RemotePath: RawByteString): TRcloneFileList;
@@ -430,10 +429,7 @@ begin
   if RunCommand(['lsjson', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0) then
     Result := ParseLsJson(Output)
   else
-  begin
     FLastError := ErrorOutput;
-    Result := TRcloneFileList.Create(True);
-  end;
 end;
 
 function TRcloneCli.CopyToLocal(const RemotePath, LocalPath: RawByteString): Integer;

--- a/wfx/rclone/src/urclonecli.pas
+++ b/wfx/rclone/src/urclonecli.pas
@@ -3,7 +3,7 @@
    -------------------------------------------------------------------------
    WFX plugin for working with rclone remotes - CLI wrapper
 
-   Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+   Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/wfx/rclone/src/urclonecli.pas
+++ b/wfx/rclone/src/urclonecli.pas
@@ -27,7 +27,7 @@ unit uRcloneCli;
 interface
 
 uses
-  Classes, SysUtils, Process, WfxPlugin, uRcloneJson;
+  Classes, SysUtils, Process, Pipes, WfxPlugin, uRcloneJson;
 
 type
   TProgressCallback = function(SourceName, TargetName: PWideChar;
@@ -40,7 +40,7 @@ type
     FProgressProc: TProgressCallback;
     FPluginNr: Integer;
     function RunCommand(const Args: array of AnsiString; out Output: AnsiString;
-      out ExitCode: Integer): Boolean;
+      out ErrorOutput: AnsiString; out ExitCode: Integer): Boolean;
     function RunCommandWithProgress(const Args: array of AnsiString;
       const SourceName, TargetName: UnicodeString;
       out ExitCode: Integer): Boolean;
@@ -159,23 +159,44 @@ begin
   Result := GetHomeDir + '/.config/rclone/rclone.conf';
 end;
 
+{ Read everything currently buffered in a pipe without blocking.
+  Returns the number of bytes appended to AStream. }
+function DrainPipe(APipe: TInputPipeStream; AStream: TStringStream): Integer;
+var
+  Buffer: array[0..4095] of Byte;
+  Avail, BytesRead: Integer;
+begin
+  Result := 0;
+  if APipe = nil then Exit;
+  repeat
+    Avail := APipe.NumBytesAvailable;
+    if Avail <= 0 then Break;
+    if Avail > SizeOf(Buffer) then
+      Avail := SizeOf(Buffer);
+    BytesRead := APipe.Read(Buffer, Avail);
+    if BytesRead <= 0 then Break;
+    AStream.Write(Buffer, BytesRead);
+    Inc(Result, BytesRead);
+  until False;
+end;
+
 function TRcloneCli.RunCommand(const Args: array of AnsiString;
-  out Output: AnsiString; out ExitCode: Integer): Boolean;
+  out Output: AnsiString; out ErrorOutput: AnsiString; out ExitCode: Integer): Boolean;
 var
   AProcess: TProcess;
   I: Integer;
-  OutputStream: TStringStream;
-  BytesRead: Integer;
-  Buffer: array[0..4095] of Byte;
+  OutputStream, ErrorStream: TStringStream;
   ConfigPath: AnsiString;
 begin
   Result := False;
   Output := '';
+  ErrorOutput := '';
   ExitCode := -1;
   FLastError := '';
 
   AProcess := TProcess.Create(nil);
   OutputStream := TStringStream.Create('');
+  ErrorStream := TStringStream.Create('');
   try
     AProcess.Executable := FRclonePath;
 
@@ -194,30 +215,27 @@ begin
     AProcess.Environment.Add('PATH=/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin');
     AProcess.Environment.Add('HOME=' + GetHomeDir);
 
-    AProcess.Options := [poUsePipes, poStderrToOutPut, poNoConsole];
+    // Keep stderr separate: rclone writes log messages (e.g. the SFTP
+    // "No host key validation is being performed" NOTICE) to stderr, and
+    // merging them into stdout would corrupt the JSON of lsjson & friends.
+    AProcess.Options := [poUsePipes, poNoConsole];
 
     try
       AProcess.Execute;
 
-      // Read output
-      while AProcess.Running or (AProcess.Output.NumBytesAvailable > 0) do
-      begin
-        BytesRead := AProcess.Output.Read(Buffer, SizeOf(Buffer));
-        if BytesRead > 0 then
-          OutputStream.Write(Buffer, BytesRead)
-        else
-          Sleep(10);
-      end;
-
-      // Read any remaining output
+      // Drain both pipes until the process is gone and nothing is left
       repeat
-        BytesRead := AProcess.Output.Read(Buffer, SizeOf(Buffer));
-        if BytesRead > 0 then
-          OutputStream.Write(Buffer, BytesRead);
-      until BytesRead = 0;
+        if DrainPipe(AProcess.Output, OutputStream) +
+           DrainPipe(AProcess.Stderr, ErrorStream) = 0 then
+        begin
+          if not AProcess.Running then Break;
+          Sleep(10);
+        end;
+      until False;
 
       ExitCode := AProcess.ExitCode;
       Output := OutputStream.DataString;
+      ErrorOutput := ErrorStream.DataString;
       Result := True;
     except
       on E: Exception do
@@ -227,6 +245,7 @@ begin
       end;
     end;
   finally
+    ErrorStream.Free;
     OutputStream.Free;
     AProcess.Free;
   end;
@@ -378,27 +397,30 @@ end;
 
 function TRcloneCli.ListRemotes: TStringList;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
   Result := nil;
-  if RunCommand(['listremotes'], Output, ExitCode) and (ExitCode = 0) then
+  if RunCommand(['listremotes'], Output, ErrorOutput, ExitCode) and (ExitCode = 0) then
     Result := ParseListRemotes(Output)
   else
+  begin
+    FLastError := ErrorOutput;
     Result := TStringList.Create;
+  end;
 end;
 
 function TRcloneCli.ListDirectory(const RemotePath: AnsiString): TRcloneFileList;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
   Result := nil;
-  if RunCommand(['lsjson', RemotePath], Output, ExitCode) and (ExitCode = 0) then
+  if RunCommand(['lsjson', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0) then
     Result := ParseLsJson(Output)
   else
   begin
-    FLastError := Output;
+    FLastError := ErrorOutput;
     Result := TRcloneFileList.Create(True);
   end;
 end;
@@ -441,42 +463,42 @@ end;
 
 function TRcloneCli.DeleteFile(const RemotePath: AnsiString): Boolean;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
-  Result := RunCommand(['delete', RemotePath], Output, ExitCode) and (ExitCode = 0);
+  Result := RunCommand(['delete', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
   if not Result then
-    FLastError := Output;
+    FLastError := ErrorOutput;
 end;
 
 function TRcloneCli.DeleteDir(const RemotePath: AnsiString): Boolean;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
-  Result := RunCommand(['rmdir', RemotePath], Output, ExitCode) and (ExitCode = 0);
+  Result := RunCommand(['rmdir', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
   if not Result then
-    FLastError := Output;
+    FLastError := ErrorOutput;
 end;
 
 function TRcloneCli.MakeDir(const RemotePath: AnsiString): Boolean;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
-  Result := RunCommand(['mkdir', RemotePath], Output, ExitCode) and (ExitCode = 0);
+  Result := RunCommand(['mkdir', RemotePath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
   if not Result then
-    FLastError := Output;
+    FLastError := ErrorOutput;
 end;
 
 function TRcloneCli.MoveFile(const OldPath, NewPath: AnsiString): Boolean;
 var
-  Output: AnsiString;
+  Output, ErrorOutput: AnsiString;
   ExitCode: Integer;
 begin
-  Result := RunCommand(['moveto', OldPath, NewPath], Output, ExitCode) and (ExitCode = 0);
+  Result := RunCommand(['moveto', OldPath, NewPath], Output, ErrorOutput, ExitCode) and (ExitCode = 0);
   if not Result then
-    FLastError := Output;
+    FLastError := ErrorOutput;
 end;
 
 function RcloneExitToWfx(ExitCode: Integer; const ErrorOutput: AnsiString): Integer;

--- a/wfx/rclone/src/urclonefunc.pas
+++ b/wfx/rclone/src/urclonefunc.pas
@@ -3,7 +3,7 @@
    -------------------------------------------------------------------------
    WFX plugin for working with rclone remotes
 
-   Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+   Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/wfx/rclone/src/urclonefunc.pas
+++ b/wfx/rclone/src/urclonefunc.pas
@@ -84,6 +84,27 @@ type
 var
   gRcloneCli: TRcloneCli;
 
+{ Report a failure to the user through Double Commander's log window. Without this a
+  failed listing is indistinguishable from an empty directory, since both leave the
+  panel empty. }
+procedure LogError(const Operation: UnicodeString; const RcloneError: RawByteString);
+var
+  Message: UnicodeString;
+  I: Integer;
+begin
+  if not Assigned(gLogProc) then Exit;
+  Message := Operation;
+  if RcloneError <> '' then
+  begin
+    Message := Message + ': ' + UTF8ToWide(RcloneError);
+    // Keep it to a single log line
+    for I := 1 to Length(Message) do
+      if (Message[I] = #13) or (Message[I] = #10) then
+        Message[I] := ' ';
+  end;
+  gLogProc(gPluginNr, msgtype_importanterror, PWideChar(Message));
+end;
+
 function ProgressCallback(SourceName, TargetName: PWideChar;
   PercentDone: Integer): Integer;
 begin
@@ -178,7 +199,7 @@ begin
   if IsRootPath(PathStr) then
   begin
     ListRec^.RemoteList := gRcloneCli.ListRemotes;
-    if ListRec^.RemoteList.Count > 0 then
+    if (ListRec^.RemoteList <> nil) and (ListRec^.RemoteList.Count > 0) then
     begin
       FillRemoteFindData(FindData, UTF8ToWide(ListRec^.RemoteList[0]));
       ListRec^.Index := 1;
@@ -186,6 +207,10 @@ begin
     end
     else
     begin
+      // nil means rclone itself failed; an empty list just means no remotes
+      if ListRec^.RemoteList = nil then
+        LogError('rclone listremotes failed', gRcloneCli.LastError);
+      FreeAndNil(ListRec^.RemoteList);
       Dispose(ListRec);
     end;
   end
@@ -206,10 +231,13 @@ begin
     end
     else
     begin
-      // Empty directory or error - return invalid handle
-      // but first check if we got any data at all
-      if ListRec^.FileList <> nil then
-        ListRec^.FileList.Free;
+      // Either way there is nothing to enumerate, so the handle stays invalid and
+      // Double Commander shows an empty panel. Only a nil list is an actual failure,
+      // and that one gets reported rather than passed off as an empty directory.
+      if ListRec^.FileList = nil then
+        LogError('rclone lsjson failed for ' + BuildRclonePath(RemoteName, RemotePath),
+                 gRcloneCli.LastError);
+      FreeAndNil(ListRec^.FileList);
       Dispose(ListRec);
     end;
   end;

--- a/wfx/rclone/src/urclonejson.pas
+++ b/wfx/rclone/src/urclonejson.pas
@@ -67,16 +67,27 @@ var
   JsonData: TJSONData;
   JsonArray: TJSONArray;
   JsonObj: TJSONObject;
-  I: Integer;
+  I, StartPos: Integer;
   RcloneFile: TRcloneFile;
+  Text: AnsiString;
 begin
   Result := TRcloneFileList.Create(True);
 
-  if Trim(JsonOutput) = '' then
+  Text := Trim(JsonOutput);
+  if Text = '' then
     Exit;
 
+  // Be tolerant of anything printed before the array (log lines, warnings)
+  if Text[1] <> '[' then
+  begin
+    StartPos := Pos('[', Text);
+    if StartPos = 0 then
+      Exit;
+    Text := Copy(Text, StartPos, Length(Text) - StartPos + 1);
+  end;
+
   try
-    JsonData := GetJSON(JsonOutput);
+    JsonData := GetJSON(Text);
     try
       if not (JsonData is TJSONArray) then
         Exit;
@@ -134,11 +145,12 @@ begin
     for I := 0 to Lines.Count - 1 do
     begin
       RemoteName := Trim(Lines[I]);
-      // rclone listremotes outputs "remotename:" - remove the trailing colon
-      if (Length(RemoteName) > 0) and (RemoteName[Length(RemoteName)] = ':') then
-        RemoteName := Copy(RemoteName, 1, Length(RemoteName) - 1);
-      if RemoteName <> '' then
-        Result.Add(RemoteName);
+      // rclone listremotes outputs "remotename:" - anything without the
+      // trailing colon is not a remote (e.g. a stray log line)
+      if (Length(RemoteName) < 2) or (RemoteName[Length(RemoteName)] <> ':') then
+        Continue;
+      RemoteName := Copy(RemoteName, 1, Length(RemoteName) - 1);
+      Result.Add(RemoteName);
     end;
   finally
     Lines.Free;

--- a/wfx/rclone/src/urclonejson.pas
+++ b/wfx/rclone/src/urclonejson.pas
@@ -3,7 +3,7 @@
    -------------------------------------------------------------------------
    WFX plugin for working with rclone remotes - JSON parsing
 
-   Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+   Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/wfx/rclone/src/urclonejson.pas
+++ b/wfx/rclone/src/urclonejson.pas
@@ -46,30 +46,30 @@ type
     property Items[Index: Integer]: TRcloneFile read GetItem; default;
   end;
 
-{ Parse rclone lsjson output }
-function ParseLsJson(const JsonOutput: AnsiString): TRcloneFileList;
+{ Parse rclone lsjson output (raw UTF-8 bytes as printed by rclone) }
+function ParseLsJson(const JsonOutput: RawByteString): TRcloneFileList;
 
 { Parse rclone listremotes output }
-function ParseListRemotes(const Output: AnsiString): TStringList;
+function ParseListRemotes(const Output: RawByteString): TStringList;
 
 implementation
 
 uses
-  fpjson, jsonparser;
+  fpjson, jsonparser, uRcloneUtil;
 
 function TRcloneFileList.GetItem(Index: Integer): TRcloneFile;
 begin
   Result := TRcloneFile(inherited Items[Index]);
 end;
 
-function ParseLsJson(const JsonOutput: AnsiString): TRcloneFileList;
+function ParseLsJson(const JsonOutput: RawByteString): TRcloneFileList;
 var
   JsonData: TJSONData;
   JsonArray: TJSONArray;
   JsonObj: TJSONObject;
   I, StartPos: Integer;
   RcloneFile: TRcloneFile;
-  Text: AnsiString;
+  Text: RawByteString;
 begin
   Result := TRcloneFileList.Create(True);
 
@@ -102,9 +102,10 @@ begin
         JsonObj := TJSONObject(JsonArray.Items[I]);
         RcloneFile := TRcloneFile.Create;
 
-        // Parse Name
+        // Parse Name. The explicit TJSONStringType cast picks the byte-string
+        // overload of Get, so the name arrives as UTF-8 and is decoded exactly once.
         if JsonObj.Find('Name') <> nil then
-          RcloneFile.Name := UTF8Decode(JsonObj.Get('Name', ''));
+          RcloneFile.Name := UTF8ToWide(JsonObj.Get('Name', TJSONStringType('')));
 
         // Parse Size
         if JsonObj.Find('Size') <> nil then
@@ -132,11 +133,11 @@ begin
   end;
 end;
 
-function ParseListRemotes(const Output: AnsiString): TStringList;
+function ParseListRemotes(const Output: RawByteString): TStringList;
 var
   Lines: TStringList;
   I: Integer;
-  RemoteName: AnsiString;
+  RemoteName: RawByteString;
 begin
   Result := TStringList.Create;
   Lines := TStringList.Create;

--- a/wfx/rclone/src/urcloneutil.pas
+++ b/wfx/rclone/src/urcloneutil.pas
@@ -3,7 +3,7 @@
    -------------------------------------------------------------------------
    WFX plugin for working with rclone remotes
 
-   Copyright (C) 2026 Miklos Mukka Szel <contact@miklos-szel.com>
+   Copyright (C) 2026 Miklos Mukka Szel <hello@miklos-szel.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/wfx/rclone/src/urcloneutil.pas
+++ b/wfx/rclone/src/urcloneutil.pas
@@ -36,8 +36,8 @@ function BuildRclonePath(const RemoteName, RemotePath: UnicodeString): UnicodeSt
 function IsRootPath(const Path: UnicodeString): Boolean;
 
 { String conversion utilities }
-function WideToUTF8(const S: UnicodeString): AnsiString;
-function UTF8ToWide(const S: AnsiString): UnicodeString;
+function WideToUTF8(const S: UnicodeString): RawByteString;
+function UTF8ToWide(const S: RawByteString): UnicodeString;
 function StrToFileTime(const ISOTime: AnsiString): TFileTime;
 
 { File attribute helpers }
@@ -97,8 +97,12 @@ begin
   else
     Result := '';
 
-  // Convert backslashes to forward slashes for rclone
-  Result := StringReplace(Result, '\', '/', [rfReplaceAll]);
+  // Convert backslashes to forward slashes for rclone. Done in place rather than with
+  // StringReplace, which has no UnicodeString overload and would round-trip the path
+  // through the system code page.
+  for I := 1 to Length(Result) do
+    if Result[I] = '\' then
+      Result[I] := '/';
 end;
 
 function BuildRclonePath(const RemoteName, RemotePath: UnicodeString): UnicodeString;
@@ -114,14 +118,41 @@ begin
   Result := (Path = '/') or (Path = '\') or (Path = '');
 end;
 
-function WideToUTF8(const S: UnicodeString): AnsiString;
+{ Convert UTF-16 to UTF-8 bytes.
+
+  Uses the System unit primitives rather than UTF8Encode/UTF8Decode on purpose: those
+  go through the widestring manager, which without cwstring maps every code point above
+  U+007F to '?'. RawByteString (CP_NONE) keeps the compiler from inserting an implicit
+  code page conversion at the call sites. }
+function WideToUTF8(const S: UnicodeString): RawByteString;
+var
+  Len: SizeUInt;
 begin
-  Result := UTF8Encode(S);
+  Result := '';
+  if S = '' then Exit;
+  // Worst case is 3 bytes per UTF-16 code unit, plus the terminating #0
+  SetLength(Result, Length(S) * 3 + 1);
+  Len := System.UnicodeToUtf8(PAnsiChar(Result), Length(Result), PUnicodeChar(S), Length(S));
+  if Len > 1 then
+    SetLength(Result, Len - 1)  // Len counts the terminating #0
+  else
+    Result := '';
 end;
 
-function UTF8ToWide(const S: AnsiString): UnicodeString;
+{ Convert UTF-8 bytes to UTF-16. See the note on WideToUTF8. }
+function UTF8ToWide(const S: RawByteString): UnicodeString;
+var
+  Len: SizeUInt;
 begin
-  Result := UTF8Decode(S);
+  Result := '';
+  if S = '' then Exit;
+  // UTF-8 never expands: at most one UTF-16 code unit per byte, plus the terminating #0
+  SetLength(Result, Length(S) + 1);
+  Len := System.Utf8ToUnicode(PUnicodeChar(Result), Length(Result), PAnsiChar(S), Length(S));
+  if Len > 1 then
+    SetLength(Result, Len - 1)  // Len counts the terminating #0
+  else
+    Result := '';
 end;
 
 function StrToFileTime(const ISOTime: AnsiString): TFileTime;


### PR DESCRIPTION
### Problem

Browsing any remote that makes rclone emit a log message fails - the panel shows an empty or unreadable directory. Easiest way to reproduce is an SFTP remote without `known_hosts_file`:

```
$ rclone lsjson hetenc:
2026/08/13 09:09:28 NOTICE: het: No host key validation is being performed. Set known_hosts_file to enable it. See: https://rclone.org/sftp/#host-key-validation
[
{"Path":".AppleDB", ...
```

### Cause

That notice goes to **stderr**, but `TRcloneCli.RunCommand` ran the child process with `poStderrToOutPut`, so the log lines were prepended to the stdout of `lsjson`. The result is not valid JSON, `GetJSON` raises, `ParseLsJson` swallows the exception and returns an empty list, and `FsFindFirstW` reports an empty directory.

### Fix

Capture stdout and stderr on separate pipes, draining both in a single loop so neither pipe buffer can fill up and block the child process. `LastError` now carries the actual rclone error message instead of a mix of both streams.

`RunCommandWithProgress` keeps `poStderrToOutPut` on purpose - that is where `--progress` writes.

Additionally the parsers are made tolerant of unexpected output, so a stray line can never silently blank a listing again:

* `ParseLsJson` skips anything printed before the JSON array.
* `ParseListRemotes` only accepts lines ending with a colon, which is the format `listremotes` prints.

### Testing

Tested on macOS against an SFTP remote that triggers the notice: listing, entering directories, and `listremotes` at the root all work again.